### PR TITLE
fix: outdated name and address in Public Resolver

### DIFF
--- a/src/RNSUnified.sol
+++ b/src/RNSUnified.sol
@@ -51,6 +51,11 @@ contract RNSUnified is Initializable, RNSToken {
   }
 
   /// @inheritdoc INSUnified
+  function namehash(string memory) external pure returns (uint256) {
+    revert("TODO");
+  }
+
+  /// @inheritdoc INSUnified
   function available(uint256 id) public view returns (bool) {
     return block.timestamp > LibSafeRange.add(_expiry(id), _gracePeriod);
   }
@@ -182,7 +187,7 @@ contract RNSUnified is Initializable, RNSToken {
 
   /// @dev Override {ERC721-ownerOf}.
   function ownerOf(uint256 tokenId) public view override(ERC721, IERC721) returns (address) {
-    if (_isExpired(tokenId)) revert Expired();
+    if (_isExpired(tokenId)) return address(0);
     return super.ownerOf(tokenId);
   }
 

--- a/src/interfaces/INSUnified.sol
+++ b/src/interfaces/INSUnified.sol
@@ -97,6 +97,11 @@ interface INSUnified is IERC721Metadata {
   function RESERVATION_ROLE() external pure returns (bytes32);
 
   /**
+   * @dev Returns the name hash output of a domain.
+   */
+  function namehash(string memory domain) external view returns (uint256 id);
+
+  /**
    * @dev Returns true if the specified name is available for registration.
    * Note: Only available after passing the grace period.
    */

--- a/src/resolvers/NameResolvable.sol
+++ b/src/resolvers/NameResolvable.sol
@@ -21,7 +21,7 @@ abstract contract NameResolvable is INameResolver, BaseVersion {
   /**
    * @inheritdoc INameResolver
    */
-  function name(bytes32 node) external view virtual override returns (string memory) {
+  function name(bytes32 node) public view virtual override returns (string memory) {
     return _versionName[_recordVersion[node]][node];
   }
 

--- a/src/resolvers/PublicResolver.sol
+++ b/src/resolvers/PublicResolver.sol
@@ -118,6 +118,7 @@ contract PublicResolver is
 
   /// @inheritdoc IAddressResolver
   function setAddr(bytes32 node, address addr_) external onlyAuthorized(node) {
+    revert("PublicResolver: Cannot set address");
     _setAddr(node, addr_);
   }
 
@@ -169,7 +170,15 @@ contract PublicResolver is
     override(AddressResolvable, IAddressResolver, InterfaceResolvable)
     returns (address payable)
   {
-    return super.addr(node);
+    return payable(_rnsUnified.ownerOf(uint256(node)));
+  }
+
+  /// @dev Override {INameResolver-name}.
+  function name(bytes32 node) public view virtual override(INameResolver, NameResolvable) returns (string memory) {
+    address reversedAddress = _reverseRegistrar.getAddress(node);
+    string memory domainName = super.name(node);
+    uint256 tokenId = _rnsUnified.namehash(domainName);
+    return _rnsUnified.ownerOf(tokenId) == reversedAddress ? domainName : "";
   }
 
   /**


### PR DESCRIPTION
### Description
This PR is mainly to fix the following issues related to the setting of name and address on the public resolver:

1. The `name(node)` method now handles cases where the name is no longer owned by the reversed owner by automatically falling back to an empty string (`""`).
2. The `addr(node)` method consistently returns the NFT owner address.
3. The `setAddr(node)` method is deprecated and no longer supported.


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
