### PR TITLE
feat: ReverseRegistrar support resolvers

### DIFF
--- a/src/interfaces/IReverseRegistrar.sol
+++ b/src/interfaces/IReverseRegistrar.sol
@@ -61,6 +61,12 @@ interface IReverseRegistrar is IERC181 {
   function setNameForAddr(address addr, string memory name) external returns (bytes32 node);
 
   /**
+   * @dev Returns address that the reverse node resolves for.
+   * Eg. node namehash('{addr}.addr.reverse') will always resolve for `addr`.
+   */
+  function getAddress(bytes32 node) external view returns (address);
+
+  /**
    * @dev Returns the node hash for a given account's reverse records.
    * @param addr The address to hash
    * @return The INS node hash.


### PR DESCRIPTION
### Description
Introducing a new method `getAddress(bytes32 node)` to the `ReverseRegistrar` contract. The implementation of this method depends on the public resolver contract, which can be found at the following location: https://github.com/axieinfinity/rns-contracts/blob/48626645b764cfee075a9954236eed37c1456d2d/src/interfaces/IReverseRegistrar.sol#L4-L10

**Changes:**

* Added the getAddress(bytes32 node) method to the ReverseRegistrar contract.

**Dependencies:**

* The implementation of the `getAddress(bytes32 node)` method relies on the [`IReverseRegistrar`](https://github.com/axieinfinity/rns-contracts/blob/48626645b764cfee075a9954236eed37c1456d2d/src/interfaces/IReverseRegistrar.sol).

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
