### PR TITLE
feat: implement Auction contract for RNS

### DIFF
--- a/src/RNSAuction.sol
+++ b/src/RNSAuction.sol
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { INSUnified, INSAuction } from "./interfaces/INSAuction.sol";
+import { LibSafeRange } from "./libraries/math/LibSafeRange.sol";
+import { LibRNSDomain } from "./libraries/LibRNSDomain.sol";
+import { LibEventRange, EventRange } from "./libraries/LibEventRange.sol";
+import { RONTransferHelper } from "./libraries/transfers/RONTransferHelper.sol";
+
+contract RNSAuction is Initializable, AccessControlEnumerable, INSAuction {
+  using LibSafeRange for uint256;
+  using LibEventRange for EventRange;
+
+  /// @inheritdoc INSAuction
+  uint64 public constant MAX_EXPIRY = type(uint64).max;
+  /// @inheritdoc INSAuction
+  uint256 public constant MAX_PERCENTAGE = 100_00;
+  /// @inheritdoc INSAuction
+  uint64 public constant DOMAIN_EXPIRY_DURATION = 365 days;
+  /// @inheritdoc INSAuction
+  bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+
+  /// @dev Gap for upgradeability.
+  uint256[50] private ____gap;
+
+  /// @dev The RNSUnified contract.
+  INSUnified internal _rnsUnified;
+  /// @dev Mapping from auction Id => event range
+  mapping(bytes32 auctionId => EventRange) internal _auctionRange;
+  /// @dev Mapping from id of domain names => auction detail.
+  mapping(uint256 id => DomainAuction) internal _domainAuction;
+
+  /// @dev The treasury.
+  address payable internal _treasury;
+  /// @dev The gap ratio between 2 bids with the starting price.
+  uint256 internal _bidGapRatio;
+
+  modifier whenNotStarted(bytes32 auctionId) {
+    _requireNotStarted(auctionId);
+    _;
+  }
+
+  modifier onlyValidEventRange(EventRange calldata range) {
+    _requireValidEventRange(range);
+    _;
+  }
+
+  constructor() payable {
+    _disableInitializers();
+  }
+
+  function initialize(
+    address admin,
+    address[] calldata operators,
+    INSUnified rnsUnified,
+    address payable treasury,
+    uint256 bidGapRatio
+  ) external initializer {
+    _setTreasury(treasury);
+    _setBidGapRatio(bidGapRatio);
+    _setupRole(DEFAULT_ADMIN_ROLE, admin);
+
+    uint256 length = operators.length;
+    bytes32 operatorRole = OPERATOR_ROLE;
+
+    for (uint256 i; i < length;) {
+      _setupRole(operatorRole, operators[i]);
+
+      unchecked {
+        ++i;
+      }
+    }
+
+    _rnsUnified = rnsUnified;
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function bulkRegister(string[] calldata labels) external onlyRole(OPERATOR_ROLE) returns (uint256[] memory ids) {
+    uint256 length = labels.length;
+    if (length == 0) revert InvalidArrayLength();
+    ids = new uint256[](length);
+    INSUnified rnsUnified = _rnsUnified;
+    uint256 parentId = LibRNSDomain.RON_ID;
+    uint64 domainExpiryDuration = DOMAIN_EXPIRY_DURATION;
+
+    for (uint256 i; i < length;) {
+      (, ids[i]) = rnsUnified.mint(parentId, labels[i], address(0x0), address(this), domainExpiryDuration);
+
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function reserved(uint256 id) public view returns (bool) {
+    return _rnsUnified.ownerOf(id) == address(this);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function createAuctionEvent(EventRange calldata range)
+    external
+    onlyRole(DEFAULT_ADMIN_ROLE)
+    onlyValidEventRange(range)
+    returns (bytes32 auctionId)
+  {
+    auctionId = keccak256(abi.encode(_msgSender(), range));
+    _auctionRange[auctionId] = range;
+    emit AuctionEventSet(auctionId, range);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function setAuctionEvent(bytes32 auctionId, EventRange calldata range)
+    external
+    onlyRole(DEFAULT_ADMIN_ROLE)
+    onlyValidEventRange(range)
+    whenNotStarted(auctionId)
+  {
+    _auctionRange[auctionId] = range;
+    emit AuctionEventSet(auctionId, range);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function getAuctionEvent(bytes32 auctionId) public view returns (EventRange memory) {
+    return _auctionRange[auctionId];
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function listNamesForAuction(bytes32 auctionId, uint256[] calldata ids, uint256[] calldata startingPrices)
+    external
+    onlyRole(OPERATOR_ROLE)
+    whenNotStarted(auctionId)
+  {
+    uint256 length = ids.length;
+    if (length == 0 || length != startingPrices.length) revert InvalidArrayLength();
+    uint256 id;
+    bytes32 mAuctionId;
+    DomainAuction storage sAuction;
+
+    for (uint256 i; i < length;) {
+      id = ids[i];
+      if (!reserved(id)) revert NameNotReserved();
+
+      sAuction = _domainAuction[id];
+      mAuctionId = sAuction.auctionId;
+      if (!(mAuctionId == 0 || mAuctionId == auctionId || sAuction.bid.timestamp == 0)) {
+        revert AlreadyBidding();
+      }
+
+      sAuction.auctionId = auctionId;
+      sAuction.startingPrice = startingPrices[i];
+
+      unchecked {
+        ++i;
+      }
+    }
+
+    emit LabelsListed(auctionId, ids, startingPrices);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function placeBid(uint256 id) external payable {
+    DomainAuction memory auction = _domainAuction[id];
+    EventRange memory range = _auctionRange[auction.auctionId];
+    uint256 beatPrice = _getBeatPrice(auction, range);
+
+    if (!range.isInPeriod()) revert QueryIsNotInPeriod();
+    if (msg.value < beatPrice) revert InsufficientAmount();
+    address payable bidder = payable(_msgSender());
+    // check whether the bidder can receive RON
+    if (!RONTransferHelper.send(bidder, 0)) revert BidderCannotReceiveRON();
+    address payable prvBidder = auction.bid.bidder;
+    uint256 prvPrice = auction.bid.price;
+
+    Bid storage sBid = _domainAuction[id].bid;
+    sBid.price = msg.value;
+    sBid.bidder = bidder;
+    sBid.timestamp = block.timestamp;
+    emit BidPlaced(auction.auctionId, id, msg.value, bidder, prvPrice, prvBidder);
+
+    // refund for previous bidder
+    if (prvPrice != 0) RONTransferHelper.safeTransfer(prvBidder, prvPrice);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function bulkClaimBidNames(uint256[] calldata ids) external returns (bool[] memory claimeds) {
+    uint256 id;
+    uint256 accumulatedRON;
+    EventRange memory range;
+    DomainAuction memory auction;
+    uint256 length = ids.length;
+    claimeds = new bool[](length);
+    INSUnified rnsUnified = _rnsUnified;
+    uint64 expiry = uint64(block.timestamp.addWithUpperbound(DOMAIN_EXPIRY_DURATION, MAX_EXPIRY));
+
+    for (uint256 i; i < length;) {
+      id = ids[i];
+      auction = _domainAuction[id];
+      range = _auctionRange[auction.auctionId];
+
+      if (!auction.bid.claimed) {
+        if (!range.isEnded()) revert NotYetEnded();
+        if (auction.bid.timestamp == 0) revert NoOneBidded();
+
+        accumulatedRON += auction.bid.price;
+        rnsUnified.setExpiry(id, expiry);
+        rnsUnified.transferFrom(address(this), auction.bid.bidder, id);
+
+        _domainAuction[id].bid.claimed = claimeds[i] = true;
+      }
+
+      unchecked {
+        ++i;
+      }
+    }
+
+    RONTransferHelper.safeTransfer(_treasury, accumulatedRON);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function getRNSUnified() external view returns (INSUnified) {
+    return _rnsUnified;
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function getTreasury() external view returns (address) {
+    return _treasury;
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function getBidGapRatio() external view returns (uint256) {
+    return _bidGapRatio;
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function setTreasury(address payable addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    _setTreasury(addr);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+
+  function setBidGapRatio(uint256 ratio) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    _setBidGapRatio(ratio);
+  }
+
+  /**
+   * @inheritdoc INSAuction
+   */
+  function getAuction(uint256 id) public view returns (DomainAuction memory auction, uint256 beatPrice) {
+    auction = _domainAuction[id];
+    EventRange memory range = getAuctionEvent(auction.auctionId);
+    beatPrice = _getBeatPrice(auction, range);
+  }
+
+  /**
+   * @dev Helper method to set treasury.
+   *
+   * Emits an event {TreasuryUpdated}.
+   */
+  function _setTreasury(address payable addr) internal {
+    if (addr == address(0)) revert NullAssignment();
+    _treasury = addr;
+    emit TreasuryUpdated(addr);
+  }
+
+  /**
+   * @dev Helper method to set bid gap ratio.
+   *
+   * Emits an event {BidGapRatioUpdated}.
+   */
+  function _setBidGapRatio(uint256 ratio) internal {
+    if (ratio > MAX_PERCENTAGE) revert RatioIsTooLarge();
+    _bidGapRatio = ratio;
+    emit BidGapRatioUpdated(ratio);
+  }
+
+  /**
+   * @dev Helper method to get beat price.
+   */
+  function _getBeatPrice(DomainAuction memory auction, EventRange memory range)
+    internal
+    view
+    returns (uint256 beatPrice)
+  {
+    beatPrice = Math.max(auction.startingPrice, auction.bid.price);
+    // Beats price increases if domain is already bided and the event is not yet ended.
+    if (auction.bid.price != 0 && !range.isEnded()) {
+      beatPrice += Math.mulDiv(auction.startingPrice, _bidGapRatio, MAX_PERCENTAGE);
+    }
+  }
+
+  /**
+   * @dev Helper method to ensure event range is valid.
+   */
+  function _requireValidEventRange(EventRange calldata range) internal view {
+    if (!(range.valid() && range.isNotYetStarted())) revert InvalidEventRange();
+  }
+
+  /**
+   * @dev Helper method to ensure the auction is not yet started or not created.
+   */
+  function _requireNotStarted(bytes32 auctionId) internal view {
+    if (!_auctionRange[auctionId].isNotYetStarted()) revert EventIsNotCreatedOrAlreadyStarted();
+  }
+}

--- a/src/interfaces/INSAuction.sol
+++ b/src/interfaces/INSAuction.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { INSUnified } from "./INSUnified.sol";
+import { EventRange } from "../libraries/LibEventRange.sol";
+
+interface INSAuction {
+  error NotYetEnded();
+  error NoOneBidded();
+  error NullAssignment();
+  error AlreadyBidding();
+  error RatioIsTooLarge();
+  error NameNotReserved();
+  error InvalidEventRange();
+  error QueryIsNotInPeriod();
+  error InsufficientAmount();
+  error InvalidArrayLength();
+  error BidderCannotReceiveRON();
+  error EventIsNotCreatedOrAlreadyStarted();
+
+  struct Bid {
+    address payable bidder;
+    uint256 price;
+    uint256 timestamp;
+    bool claimed;
+  }
+
+  struct DomainAuction {
+    bytes32 auctionId;
+    uint256 startingPrice;
+    Bid bid;
+  }
+
+  /// @dev Emitted when an auction is set.
+  event AuctionEventSet(bytes32 indexed auctionId, EventRange range);
+  /// @dev Emitted when the labels are listed for auction.
+  event LabelsListed(bytes32 indexed auctionId, uint256[] ids, uint256[] startingPrices);
+  /// @dev Emitted when a bid is placed for a name.
+  event BidPlaced(
+    bytes32 indexed auctionId,
+    uint256 indexed id,
+    uint256 price,
+    address payable bidder,
+    uint256 previousPrice,
+    address previousBidder
+  );
+  /// @dev Emitted when the treasury is updated.
+  event TreasuryUpdated(address indexed addr);
+  /// @dev Emitted when bid gap ratio is updated.
+  event BidGapRatioUpdated(uint256 ratio);
+
+  /**
+   * @dev The maximum expiry duration
+   */
+  function MAX_EXPIRY() external pure returns (uint64);
+
+  /**
+   * @dev Returns the operator role.
+   */
+  function OPERATOR_ROLE() external pure returns (bytes32);
+
+  /**
+   * @dev Max percentage 100%. Values [0; 100_00] reflexes [0; 100%]
+   */
+  function MAX_PERCENTAGE() external pure returns (uint256);
+
+  /**
+   * @dev The expiry duration of a domain after transferring to bidder.
+   */
+  function DOMAIN_EXPIRY_DURATION() external pure returns (uint64);
+
+  /**
+   * @dev Claims domain names for auction.
+   *
+   * Requirements:
+   * - The method caller must be contract operator.
+   *
+   * @param labels The domain names. Eg, ['foo'] for 'foo.ron'
+   * @return ids The id corresponding for namehash of domain names.
+   */
+  function bulkRegister(string[] calldata labels) external returns (uint256[] memory ids);
+
+  /**
+   * @dev Checks whether a domain name is currently reserved for auction or not.
+   * @param id The namehash id of domain name. Eg, namehash('foo.ron') for 'foo.ron'
+   */
+  function reserved(uint256 id) external view returns (bool);
+
+  /**
+   * @dev Creates a new auction to sale with a specific time period.
+   *
+   * Requirements:
+   * - The method caller must be admin.
+   *
+   * Emits an event {AuctionEventSet}.
+   *
+   * @return auctionId The auction id
+   * @notice Please use the method `setAuctionNames` to list all the reserved names.
+   */
+  function createAuctionEvent(EventRange calldata range) external returns (bytes32 auctionId);
+
+  /**
+   * @dev Updates the auction details.
+   *
+   * Requirements:
+   * - The method caller must be admin.
+   *
+   * Emits an event {AuctionEventSet}.
+   */
+  function setAuctionEvent(bytes32 auctionId, EventRange calldata range) external;
+
+  /**
+   * @dev Returns the event range of an auction.
+   */
+  function getAuctionEvent(bytes32 auctionId) external view returns (EventRange memory);
+
+  /**
+   * @dev Lists reserved names to sale in a specified auction.
+   *
+   * Requirements:
+   * - The method caller must be contract operator.
+   * - Array length are matched and larger than 0.
+   * - Only allow to set when the domain is:
+   *   + Not in any auction.
+   *   + Or, in the current auction.
+   *   + Or, this name is not bided.
+   *
+   * Emits an event {LabelsListed}.
+   *
+   * Note: If the name is already listed, this method replaces with a new input value.
+   *
+   * @param ids The namehashes id of domain names. Eg, namehash('foo.ron') for 'foo.ron'
+   */
+  function listNamesForAuction(bytes32 auctionId, uint256[] calldata ids, uint256[] calldata startingPrices) external;
+
+  /**
+   * @dev Places a bid for a domain name.
+   *
+   * Requirements:
+   * - The name is listed, or the auction is happening.
+   * - The msg.value is larger than the current bid price or the auction starting price.
+   *
+   * Emits an event {BidPlaced}.
+   *
+   * @param id The namehash id of domain name. Eg, namehash('foo.ron') for 'foo.ron'
+   */
+  function placeBid(uint256 id) external payable;
+
+  /**
+   * @dev Returns the highest bid and address of the bidder.
+   * @param id The namehash id of domain name. Eg, namehash('foo.ron') for 'foo.ron'
+   */
+  function getAuction(uint256 id) external view returns (DomainAuction memory, uint256 beatPrice);
+
+  /**
+   * @dev Bulk claims the bid name.
+   *
+   * Requirements:
+   * - Must be called after ended time.
+   * - The method caller can be anyone.
+   *
+   * @param ids The namehash id of domain name. Eg, namehash('foo.ron') for 'foo.ron'
+   */
+  function bulkClaimBidNames(uint256[] calldata ids) external returns (bool[] memory claimeds);
+
+  /**
+   * @dev Returns the treasury.
+   */
+  function getTreasury() external view returns (address);
+
+  /**
+   * @dev Returns the gap ratio between 2 bids with the starting price. Value in range [0;100_00] is 0%-100%.
+   */
+  function getBidGapRatio() external view returns (uint256);
+
+  /**
+   * @dev Sets the treasury.
+   *
+   * Requirements:
+   * - The method caller must be admin
+   *
+   * Emits an event {TreasuryUpdated}.
+   */
+  function setTreasury(address payable) external;
+
+  /**
+   * @dev Sets commission ratio. Value in range [0;100_00] is 0%-100%.
+   *
+   * Requirements:
+   * - The method caller must be admin
+   *
+   * Emits an event {BidGapRatioUpdated}.
+   */
+  function setBidGapRatio(uint256) external;
+
+  /**
+   * @dev Returns RNSUnified contract.
+   */
+  function getRNSUnified() external view returns (INSUnified);
+}

--- a/src/libraries/LibEventRange.sol
+++ b/src/libraries/LibEventRange.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct EventRange {
+  uint256 startedAt;
+  uint256 endedAt;
+}
+
+library LibEventRange {
+  /**
+   * @dev Checks whether the event range is valid.
+   */
+  function valid(EventRange calldata range) internal pure returns (bool) {
+    return range.startedAt <= range.endedAt;
+  }
+
+  /**
+   * @dev Returns whether the current range is not yet started.
+   */
+  function isNotYetStarted(EventRange memory range) internal view returns (bool) {
+    return block.timestamp < range.startedAt;
+  }
+
+  /**
+   * @dev Returns whether the current range is ended or not.
+   */
+  function isEnded(EventRange memory range) internal view returns (bool) {
+    return range.endedAt <= block.timestamp;
+  }
+
+  /**
+   * @dev Returns whether the current block is in period.
+   */
+  function isInPeriod(EventRange memory range) internal view returns (bool) {
+    return range.startedAt <= block.timestamp && block.timestamp < range.endedAt;
+  }
+}

--- a/src/libraries/LibRNSDomain.sol
+++ b/src/libraries/LibRNSDomain.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+library LibRNSDomain {
+  /// @dev Value equals to namehash('ron')
+  uint256 internal constant RON_ID = 0xba69923fa107dbf5a25a073a10b7c9216ae39fbadc95dc891d460d9ae315d688;
+
+  /**
+   * @dev Calculate the corresponding id given parentId and label.
+   */
+  function toId(uint256 parentId, string memory label) internal pure returns (uint256 id) {
+    assembly ("memory-safe") {
+      mstore(0x0, parentId)
+      mstore(0x20, keccak256(add(label, 32), mload(label)))
+      id := keccak256(0x0, 64)
+    }
+  }
+
+  function hashLabel(string memory label) internal pure returns (bytes32 hashed) {
+    assembly ("memory-safe") {
+      hashed := keccak256(add(label, 32), mload(label))
+    }
+  }
+}

--- a/src/libraries/transfers/RONTransferHelper.sol
+++ b/src/libraries/transfers/RONTransferHelper.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+/**
+ * @title RONTransferHelper
+ */
+library RONTransferHelper {
+  using Strings for *;
+
+  /**
+   * @dev Transfers RON and wraps result for the method caller to a recipient.
+   */
+  function safeTransfer(address payable _to, uint256 _value) internal {
+    bool _success = send(_to, _value);
+    if (!_success) {
+      revert(
+        string.concat("TransferHelper: could not transfer RON to ", _to.toHexString(), " value ", _value.toHexString())
+      );
+    }
+  }
+
+  /**
+   * @dev Returns whether the call was success.
+   * Note: this function should use with the `ReentrancyGuard`.
+   */
+  function send(address payable _to, uint256 _value) internal returns (bool _success) {
+    (_success,) = _to.call{ value: _value }(new bytes(0));
+  }
+}


### PR DESCRIPTION
### Description
This PR adds `RNSAuction` contracts and provide new interfaces to adapt with `RNSUnified`.
### Changes
#### Interface changes
- `reserved(bytes32 lbHash)` => `reserved(uint256 id)`
- `bulkRegister(bytes32[] lbHashes)` => `bulkRegister(string[] labels)`
- `listNamesForAuction(bytes32,bytes32[] lbHashes,uint256[])` => `listNamesForAuction(bytes32,uint256[] ids, uint256[])`
- `placeBid(bytes32 lbHash)` => `placeBid(uint256 id)`
- `getAuction(bytes32 lbHash)` => `getAuction(uint256 id)`
- `bulkClaimBidNames(bytes32[] lbHashes)` => `bulkClaimBidNames(uint256[] ids)`
- `getRegistrar()` => `getRNSUnified()`
#### Logic changes
- check if bidder can receive native RON else revert.
- use revert custom error instead of require string.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
