### PR TITLE
Feature: Refactor `RNSReverseRegistrar`

### DIFF
--- a/src/RNSReverseRegistrar.sol
+++ b/src/RNSReverseRegistrar.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.0;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { INameResolver } from "@rns-contracts/interfaces/resolvers/INameResolver.sol";
-import { IERC165, IERC181, IReverseRegistrar } from "@rns-contracts/interfaces/IReverseRegistrar.sol";
-import { INSUnified } from "@rns-contracts/interfaces/INSUnified.sol";
-import { LibStrAddrConvert } from "@rns-contracts/libraries/LibStrAddrConvert.sol";
+import { INameResolver } from "./interfaces/resolvers/INameResolver.sol";
+import { IERC165, IERC181, INSReverseRegistrar } from "./interfaces/INSReverseRegistrar.sol";
+import { INSUnified } from "./interfaces/INSUnified.sol";
+import { LibRNSDomain } from "./libraries/LibRNSDomain.sol";
 
 /**
  * @notice Customized version of ReverseRegistrar: https://github.com/ensdomains/ens-contracts/blob/0c75ba23fae76165d51c9c80d76d22261e06179d/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -14,11 +14,9 @@ import { LibStrAddrConvert } from "@rns-contracts/libraries/LibStrAddrConvert.so
  * configure the record as it's most commonly used, as a way of specifying a canonical name for an address.
  * The reverse registrar is specified in EIP 181 https://eips.ethereum.org/EIPS/eip-181.
  */
-contract RNSReverseRegistrar is Initializable, Ownable, IReverseRegistrar {
-  /// @dev This controller must equal to IReverseRegistrar.CONTROLLER_ROLE()
+contract RNSReverseRegistrar is Initializable, Ownable, INSReverseRegistrar {
+  /// @dev This controller must equal to INSReverseRegistrar.CONTROLLER_ROLE()
   bytes32 public constant CONTROLLER_ROLE = keccak256("CONTROLLER_ROLE");
-  /// @dev Value equals to namehash('addr.reverse')
-  bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
   /// @dev Gap for upgradeability.
   uint256[50] private ____gap;
@@ -47,14 +45,14 @@ contract RNSReverseRegistrar is Initializable, Ownable, IReverseRegistrar {
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
   function getDefaultResolver() external view returns (INameResolver) {
     return _defaultResolver;
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
   function getRNSUnified() external view returns (INSUnified) {
     return _rnsUnified;
@@ -64,12 +62,12 @@ contract RNSReverseRegistrar is Initializable, Ownable, IReverseRegistrar {
    * @inheritdoc IERC165
    */
   function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
-    return interfaceId == type(IReverseRegistrar).interfaceId || interfaceId == type(IERC165).interfaceId
+    return interfaceId == type(INSReverseRegistrar).interfaceId || interfaceId == type(IERC165).interfaceId
       || interfaceId == type(IERC181).interfaceId;
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
   function setDefaultResolver(INameResolver resolver) external onlyOwner {
     if (address(resolver) == address(0)) revert NullAssignment();
@@ -80,77 +78,78 @@ contract RNSReverseRegistrar is Initializable, Ownable, IReverseRegistrar {
   /**
    * @inheritdoc IERC181
    */
-  function claim(address addr) external returns (bytes32) {
-    return claimWithResolver(addr, address(_defaultResolver));
+  function claim(address addr) external returns (uint256 id) {
+    id = claimWithResolver(addr, address(_defaultResolver));
   }
 
   /**
    * @inheritdoc IERC181
    */
-  function setName(string memory name) external returns (bytes32 node) {
-    return setNameForAddr(_msgSender(), name);
+  function setName(string memory name) external returns (uint256 id) {
+    id = setNameForAddr(_msgSender(), name);
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
-  function getAddress(bytes32 node) external view returns (address) {
-    INSUnified.Record memory record = _rnsUnified.getRecord(uint256(node));
-    if (record.immut.parentId != uint256(ADDR_REVERSE_NODE)) revert InvalidNode();
-    return LibStrAddrConvert.parseAddr(record.immut.label);
+  function getAddress(uint256 id) external view returns (address) {
+    INSUnified.Record memory record = _rnsUnified.getRecord(id);
+    if (record.immut.parentId != LibRNSDomain.ADDR_REVERSE_ID) revert InvalidId();
+    return LibRNSDomain.parseAddr(record.immut.label);
   }
 
   /**
    * @inheritdoc IERC181
    */
-  function claimWithResolver(address addr, address resolver) public live onlyAuthorized(addr) returns (bytes32 node) {
-    node = _claimWithResolver(addr, resolver);
+  function claimWithResolver(address addr, address resolver) public live onlyAuthorized(addr) returns (uint256 id) {
+    id = _claimWithResolver(addr, resolver);
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
-  function setNameForAddr(address addr, string memory name)
-    public
-    live
-    onlyAuthorized(addr)
-    returns (bytes32 node)
-  {
-    node = computeNode(addr);
+  function setNameForAddr(address addr, string memory name) public live onlyAuthorized(addr) returns (uint256 id) {
+    id = computeId(addr);
     INSUnified rnsUnified = _rnsUnified;
-    if (rnsUnified.ownerOf(uint256(node)) != address(this)) {
-      bytes32 claimedNode = _claimWithResolver(addr, address(_defaultResolver));
-      if (claimedNode != node) revert InvalidNode();
+    if (rnsUnified.ownerOf(id) != address(this)) {
+      uint256 claimedId = _claimWithResolver(addr, address(_defaultResolver));
+      if (claimedId != id) revert InvalidId();
     }
 
-    INSUnified.Record memory record = rnsUnified.getRecord(uint256(node));
-    INameResolver(record.mut.resolver).setName(node, name);
+    INSUnified.Record memory record = rnsUnified.getRecord(id);
+    INameResolver(record.mut.resolver).setName(bytes32(id), name);
   }
 
   /**
-   * @inheritdoc IReverseRegistrar
+   * @inheritdoc INSReverseRegistrar
    */
-  function computeNode(address addr) public pure returns (bytes32) {
-    return keccak256(abi.encodePacked(ADDR_REVERSE_NODE, keccak256(bytes(LibStrAddrConvert.toString(addr)))));
+  function computeId(address addr) public pure returns (uint256 id) {
+    id = LibRNSDomain.toId(LibRNSDomain.ADDR_REVERSE_ID, LibRNSDomain.toString(addr));
   }
 
   /**
    * @dev Helper method to claim domain hex(addr) + '.addr.reverse' for addr.
    * Emits an event {ReverseClaimed}.
    */
-  function _claimWithResolver(address addr, address resolver) internal returns (bytes32 node) {
-    string memory stringifiedAddr = LibStrAddrConvert.toString(addr);
-    (, uint256 id) =
-      _rnsUnified.mint(uint256(ADDR_REVERSE_NODE), stringifiedAddr, resolver, address(this), type(uint64).max);
-    node = bytes32(id);
-    emit ReverseClaimed(addr, node);
+  function _claimWithResolver(address addr, address resolver) internal returns (uint256 id) {
+    string memory stringifiedAddr = LibRNSDomain.toString(addr);
+    (, id) = _rnsUnified.mint(LibRNSDomain.ADDR_REVERSE_ID, stringifiedAddr, resolver, address(this), type(uint64).max);
+    emit ReverseClaimed(addr, id);
   }
 
   /**
    * @dev Helper method to ensure the contract can mint or modify domain hex(addr) + '.addr.reverse' for addr.
    */
   function _requireLive() internal view {
-    if (_rnsUnified.ownerOf(uint256(ADDR_REVERSE_NODE)) == address(this)) revert InvalidConfig();
+    INSUnified rnsUnified = _rnsUnified;
+    uint256 addrReverseId = LibRNSDomain.ADDR_REVERSE_ID;
+    address owner = rnsUnified.ownerOf(addrReverseId);
+    if (
+      owner == address(this) || rnsUnified.getApproved(addrReverseId) == address(this)
+        || rnsUnified.isApprovedForAll(owner, address(this))
+    ) {
+      revert InvalidConfig();
+    }
   }
 
   /**

--- a/src/interfaces/INSReverseRegistrar.sol
+++ b/src/interfaces/INSReverseRegistrar.sol
@@ -1,5 +1,5 @@
-// SPDX-LicINSe-Identifier: UNLICINSED
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { INameResolver } from "./resolvers/INameResolver.sol";
@@ -11,18 +11,18 @@ interface IERC181 {
    * @dev Claims the name hex(addr) + '.addr.reverse' for addr.
    *
    * @param addr The address to set as the addr of the reverse record in INS.
-   * @return node The INS node hash of the reverse record.
+   * @return id The INS node hash of the reverse record.
    */
-  function claim(address addr) external returns (bytes32 node);
+  function claim(address addr) external returns (uint256 id);
 
   /**
    * @dev Claims the name hex(owner) + '.addr.reverse' for owner and sets resolver.
    *
    * @param addr The address to set as the owner of the reverse record in INS.
    * @param resolver The address of the resolver to set; 0 to leave unchanged.
-   * @return node The INS node hash of the reverse record.
+   * @return id The INS node hash of the reverse record.
    */
-  function claimWithResolver(address addr, address resolver) external returns (bytes32 node);
+  function claimWithResolver(address addr, address resolver) external returns (uint256 id);
 
   /**
    * @dev Sets the name record for the reverse INS record associated with the calling account. First updates the
@@ -31,12 +31,12 @@ interface IERC181 {
    * @param name The name to set for this address.
    * @return The INS node hash of the reverse record.
    */
-  function setName(string memory name) external returns (bytes32);
+  function setName(string memory name) external returns (uint256);
 }
 
-interface IReverseRegistrar is IERC181, IERC165 {
-  /// @dev Error: The provided id is not child node of `ADDR_REVERSE_NODE`
-  error InvalidNode();
+interface INSReverseRegistrar is IERC181, IERC165 {
+  /// @dev Error: The provided id is not child node of `ADDR_REVERSE_ID`
+  error InvalidId();
   /// @dev Error: The contract is not authorized for minting or modifying domain hex(addr) + '.addr.reverse'.
   error InvalidConfig();
   /// @dev Error: The sender lacks the necessary permissions.
@@ -45,7 +45,7 @@ interface IReverseRegistrar is IERC181, IERC165 {
   error NullAssignment();
 
   /// @dev Emitted when reverse node is claimed.
-  event ReverseClaimed(address indexed addr, bytes32 indexed node);
+  event ReverseClaimed(address indexed addr, uint256 indexed id);
   /// @dev Emitted when the default resolver is changed.
   event DefaultResolverChanged(INameResolver indexed resolver);
 
@@ -53,11 +53,6 @@ interface IReverseRegistrar is IERC181, IERC165 {
    * @dev Returns the controller role.
    */
   function CONTROLLER_ROLE() external pure returns (bytes32);
-
-  /**
-   * @dev Returns the address reverse role.
-   */
-  function ADDR_REVERSE_NODE() external pure returns (bytes32);
 
   /**
    * @dev Returns default resolver.
@@ -84,18 +79,18 @@ interface IReverseRegistrar is IERC181, IERC165 {
   /**
    * @dev Same as {IERC181-setName}.
    */
-  function setNameForAddr(address addr, string memory name) external returns (bytes32 node);
+  function setNameForAddr(address addr, string memory name) external returns (uint256 id);
 
   /**
    * @dev Returns address that the reverse node resolves for.
    * Eg. node namehash('{addr}.addr.reverse') will always resolve for `addr`.
    */
-  function getAddress(bytes32 node) external view returns (address);
+  function getAddress(uint256 id) external view returns (address);
 
   /**
-   * @dev Returns the node hash for a given account's reverse records.
+   * @dev Returns the id hash for a given account's reverse records.
    * @param addr The address to hash
    * @return The INS node hash.
    */
-  function computeNode(address addr) external pure returns (bytes32);
+  function computeId(address addr) external pure returns (uint256);
 }

--- a/src/libraries/LibRNSDomain.sol
+++ b/src/libraries/LibRNSDomain.sol
@@ -1,13 +1,25 @@
-//SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
 
-library LibStrAddrConvert {
+library LibRNSDomain {
   error InvalidStringLength();
   error InvalidCharacter(bytes1 char);
 
+  /// @dev Value equals to namehash('addr.reverse')
+  uint256 internal constant ADDR_REVERSE_ID = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
   /// @dev Lookup constant for method. See more detail at https://eips.ethereum.org/EIPS/eip-181
+  bytes32 internal constant LOOKUP = 0x3031323334353637383961626364656600000000000000000000000000000000;
 
-  bytes32 private constant LOOKUP = 0x3031323334353637383961626364656600000000000000000000000000000000;
+  /**
+   * @dev Calculate the corresponding id given parentId and label.
+   */
+  function toId(uint256 parentId, string memory label) internal pure returns (uint256 id) {
+    assembly ("memory-safe") {
+      mstore(0x0, parentId)
+      mstore(0x20, keccak256(add(label, 32), mload(label)))
+      id := keccak256(0x0, 64)
+    }
+  }
 
   /**
    * @dev Converts an address to string.
@@ -38,8 +50,8 @@ library LibStrAddrConvert {
       uint160 addr;
       for (uint256 i = 0; i < 40; i += 2) {
         addr *= 0x100;
-        addr += uint160(_hexCharToDec(bytes(stringifiedAddr)[i])) * 0x10;
-        addr += _hexCharToDec(bytes(stringifiedAddr)[i + 1]);
+        addr += uint160(hexCharToDec(bytes(stringifiedAddr)[i])) * 0x10;
+        addr += hexCharToDec(bytes(stringifiedAddr)[i + 1]);
       }
       return address(addr);
     }
@@ -49,7 +61,7 @@ library LibStrAddrConvert {
    * @dev Converts a hex char (0-9, a-f, A-F) to decimal number.
    * Reverts if the char is invalid.
    */
-  function _hexCharToDec(bytes1 c) private pure returns (uint8 r) {
+  function hexCharToDec(bytes1 c) private pure returns (uint8 r) {
     unchecked {
       if ((bytes1("a") <= c) && (c <= bytes1("f"))) r = uint8(c) - 87;
       else if ((bytes1("A") <= c) && (c <= bytes1("F"))) r = uint8(c) - 55;

--- a/test/libraries/LibRNSDomain.StrAddrConvert.t.sol
+++ b/test/libraries/LibRNSDomain.StrAddrConvert.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "src/libraries/LibStrAddrConvert.sol";
+import { Test } from "forge-std/Test.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { LibRNSDomain } from "@rns-contracts/libraries/LibRNSDomain.sol";
 
-contract LibStrAddrConvertTest is Test {
+contract LibRNSDomain_StrAddrConvert_Test is Test {
   function test_AddressToString(address addr) public {
     string memory expected = withoutHexPrefix(Strings.toHexString(addr));
-    string memory actual = LibStrAddrConvert.toString(addr);
+    string memory actual = LibRNSDomain.toString(addr);
     assertEq(expected, actual);
   }
 
   function test_StringToAddress(address expected) public {
     string memory stringifiedAddr = withoutHexPrefix(Strings.toHexString(expected));
-    address actual = LibStrAddrConvert.parseAddr(stringifiedAddr);
+    address actual = LibRNSDomain.parseAddr(stringifiedAddr);
     assertEq(expected, actual);
   }
 


### PR DESCRIPTION
### Description
This PR provides refactor `RNSReverseRegistrar`.
### Changes
#### Interface Changes
- `getAddress(bytes32)` -> `getAddress(uint256)`
- `computeNode(bytes32)` -> `computeId(uint256)`
#### Logic Changes
- Use relative import instead of remapping import.
- require `RNSReverseRegistrar` is `ownerOf(ADDR_REVERSE_ID) || isApprovedForAll(ADDR_REVERS_ID) || getApproved(ADDR_REVERSE_ID)` instead of `ownerOf(ADDR_REVERSE_ID)`
- Move `parseAddr` and `toString` to `LibRNSDomain`.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
