### PR TITLE
feat: reuse `LibRNSDomain` for namehash and compute id

### DIFF
--- a/src/RNSUnified.sol
+++ b/src/RNSUnified.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { IERC721State, IERC721, ERC721, INSUnified, RNSToken } from "./RNSToken.sol";
+import { LibRNSDomain } from "./libraries/LibRNSDomain.sol";
 import { LibSafeRange } from "./libraries/math/LibSafeRange.sol";
 import { ModifyingField, LibModifyingField } from "./libraries/LibModifyingField.sol";
 import {
@@ -13,6 +14,7 @@ import {
 } from "./types/ModifyingIndicator.sol";
 
 contract RNSUnified is Initializable, RNSToken {
+  using LibRNSDomain for string;
   using LibModifyingField for ModifyingField;
 
   bytes32 public constant CONTROLLER_ROLE = keccak256("CONTROLLER_ROLE");
@@ -80,7 +82,7 @@ contract RNSUnified is Initializable, RNSToken {
     returns (uint64 expiryTime, uint256 id)
   {
     if (!_checkOwnerRules(_msgSender(), parentId)) revert Unauthorized();
-    id = uint256(keccak256(abi.encode(parentId, keccak256(bytes(label)))));
+    id = LibRNSDomain.toId(parentId, label);
     if (!available(id)) revert Unavailable();
 
     if (_exists(id)) _burn(id);
@@ -98,38 +100,7 @@ contract RNSUnified is Initializable, RNSToken {
 
   /// @inheritdoc INSUnified
   function namehash(string memory str) public pure returns (bytes32 hashed) {
-    // notice: this method is case-sensitive, ensure the string is lowercased before calling this method
-    assembly ("memory-safe") {
-      // load str length
-      let len := mload(str)
-      // returns bytes32(0x0) if length is zero
-      if iszero(iszero(len)) {
-        let hashedLen
-        // compute pointer to str[0]
-        let head := add(str, 32)
-        // compute pointer to str[length - 1]
-        let tail := add(head, sub(len, 1))
-        // cleanup dirty bytes if contains any
-        mstore(0x0, 0)
-        // loop backwards from `tail` to `head`
-        for { let i := tail } iszero(lt(i, head)) { i := sub(i, 1) } {
-          // check if `i` is `head`
-          let isHead := eq(i, head)
-          // check if `str[i-1]` is "."
-          // `0x2e` == bytes1(".")
-          let isDotNext := eq(shr(248, mload(sub(i, 1))), 0x2e)
-          if or(isHead, isDotNext) {
-            // size = distance(length, i) - hashedLength + 1
-            let size := add(sub(sub(tail, i), hashedLen), 1)
-            mstore(0x20, keccak256(i, size))
-            mstore(0x0, keccak256(0x0, 64))
-            // skip "." thereby + 1
-            hashedLen := add(hashedLen, add(size, 1))
-          }
-        }
-      }
-      hashed := mload(0x0)
-    }
+    hashed = str.namehash();
   }
 
   /// @inheritdoc INSUnified

--- a/src/libraries/LibRNSDomain.sol
+++ b/src/libraries/LibRNSDomain.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 library LibRNSDomain {
@@ -16,9 +16,50 @@ library LibRNSDomain {
     }
   }
 
+  /**
+   * @dev Calculate the hash of the label.
+   */
   function hashLabel(string memory label) internal pure returns (bytes32 hashed) {
     assembly ("memory-safe") {
       hashed := keccak256(add(label, 32), mload(label))
+    }
+  }
+
+  /**
+   * @dev Calculate the RNS namehash of a str.
+   */
+  function namehash(string memory str) internal pure returns (bytes32 hashed) {
+    // notice: this method is case-sensitive, ensure the string is lowercased before calling this method
+    assembly ("memory-safe") {
+      // load str length
+      let len := mload(str)
+      // returns bytes32(0x0) if length is zero
+      if iszero(iszero(len)) {
+        let hashedLen
+        // compute pointer to str[0]
+        let head := add(str, 32)
+        // compute pointer to str[length - 1]
+        let tail := add(head, sub(len, 1))
+        // cleanup dirty bytes if contains any
+        mstore(0x0, 0)
+        // loop backwards from `tail` to `head`
+        for { let i := tail } iszero(lt(i, head)) { i := sub(i, 1) } {
+          // check if `i` is `head`
+          let isHead := eq(i, head)
+          // check if `str[i-1]` is "."
+          // `0x2e` == bytes1(".")
+          let isDotNext := eq(shr(248, mload(sub(i, 1))), 0x2e)
+          if or(isHead, isDotNext) {
+            // size = distance(length, i) - hashedLength + 1
+            let size := add(sub(sub(tail, i), hashedLen), 1)
+            mstore(0x20, keccak256(i, size))
+            mstore(0x0, keccak256(0x0, 64))
+            // skip "." thereby + 1
+            hashedLen := add(hashedLen, add(size, 1))
+          }
+        }
+      }
+      hashed := mload(0x0)
     }
   }
 


### PR DESCRIPTION
### Description
This PR provides minor refactor for `RNSUnified`.
### Changes
#### Logic changes
- move compute id and namehash logic to `LibRNSDomain`.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
