### PR TITLE
refactor: rename vars and check approved or owner for Reverse Registrar

### DIFF
--- a/src/RNSDomainPrice.sol
+++ b/src/RNSDomainPrice.sol
@@ -9,10 +9,12 @@ import { INSAuction } from "./interfaces/INSAuction.sol";
 import { INSDomainPrice } from "./interfaces/INSDomainPrice.sol";
 import { PeriodScaler, LibPeriodScaler, Math } from "src/libraries/math/PeriodScalingUtils.sol";
 import { TimestampWrapper } from "./libraries/TimestampWrapperUtils.sol";
+import { LibString } from "./libraries/LibString.sol";
 import { LibRNSDomain } from "./libraries/LibRNSDomain.sol";
 import { PythConverter } from "./libraries/pyth/PythConverter.sol";
 
 contract RNSDomainPrice is Initializable, AccessControlEnumerable, INSDomainPrice {
+  using LibString for *;
   using LibRNSDomain for string;
   using LibPeriodScaler for PeriodScaler;
   using PythConverter for PythStructs.Price;

--- a/src/interfaces/INSReverseRegistrar.sol
+++ b/src/interfaces/INSReverseRegistrar.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { INameResolver } from "./resolvers/INameResolver.sol";
@@ -11,18 +11,18 @@ interface IERC181 {
    * @dev Claims the name hex(addr) + '.addr.reverse' for addr.
    *
    * @param addr The address to set as the addr of the reverse record in INS.
-   * @return node The INS node hash of the reverse record.
+   * @return id The INS node hash of the reverse record.
    */
-  function claim(address addr) external returns (bytes32 node);
+  function claim(address addr) external returns (uint256 id);
 
   /**
    * @dev Claims the name hex(owner) + '.addr.reverse' for owner and sets resolver.
    *
    * @param addr The address to set as the owner of the reverse record in INS.
    * @param resolver The address of the resolver to set; 0 to leave unchanged.
-   * @return node The INS node hash of the reverse record.
+   * @return id The INS node hash of the reverse record.
    */
-  function claimWithResolver(address addr, address resolver) external returns (bytes32 node);
+  function claimWithResolver(address addr, address resolver) external returns (uint256 id);
 
   /**
    * @dev Sets the name record for the reverse INS record associated with the calling account. First updates the
@@ -31,12 +31,12 @@ interface IERC181 {
    * @param name The name to set for this address.
    * @return The INS node hash of the reverse record.
    */
-  function setName(string memory name) external returns (bytes32);
+  function setName(string memory name) external returns (uint256);
 }
 
-interface IReverseRegistrar is IERC181, IERC165 {
-  /// @dev Error: The provided id is not child node of `ADDR_REVERSE_NODE`
-  error InvalidNode();
+interface INSReverseRegistrar is IERC181, IERC165 {
+  /// @dev Error: The provided id is not child node of `ADDR_REVERSE_ID`
+  error InvalidId();
   /// @dev Error: The contract is not authorized for minting or modifying domain hex(addr) + '.addr.reverse'.
   error InvalidConfig();
   /// @dev Error: The sender lacks the necessary permissions.
@@ -45,7 +45,7 @@ interface IReverseRegistrar is IERC181, IERC165 {
   error NullAssignment();
 
   /// @dev Emitted when reverse node is claimed.
-  event ReverseClaimed(address indexed addr, bytes32 indexed node);
+  event ReverseClaimed(address indexed addr, uint256 indexed id);
   /// @dev Emitted when the default resolver is changed.
   event DefaultResolverChanged(INameResolver indexed resolver);
 
@@ -53,11 +53,6 @@ interface IReverseRegistrar is IERC181, IERC165 {
    * @dev Returns the controller role.
    */
   function CONTROLLER_ROLE() external pure returns (bytes32);
-
-  /**
-   * @dev Returns the address reverse role.
-   */
-  function ADDR_REVERSE_NODE() external pure returns (bytes32);
 
   /**
    * @dev Returns default resolver.
@@ -84,18 +79,18 @@ interface IReverseRegistrar is IERC181, IERC165 {
   /**
    * @dev Same as {IERC181-setName}.
    */
-  function setNameForAddr(address addr, string memory name) external returns (bytes32 node);
+  function setNameForAddr(address addr, string memory name) external returns (uint256 id);
 
   /**
    * @dev Returns address that the reverse node resolves for.
    * Eg. node namehash('{addr}.addr.reverse') will always resolve for `addr`.
    */
-  function getAddress(bytes32 node) external view returns (address);
+  function getAddress(uint256 id) external view returns (address);
 
   /**
-   * @dev Returns the node hash for a given account's reverse records.
+   * @dev Returns the id hash for a given account's reverse records.
    * @param addr The address to hash
    * @return The INS node hash.
    */
-  function computeNode(address addr) external pure returns (bytes32);
+  function computeId(address addr) external pure returns (uint256);
 }

--- a/src/interfaces/resolvers/IPublicResolver.sol
+++ b/src/interfaces/resolvers/IPublicResolver.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import { INSUnified } from "@rns-contracts/interfaces/INSUnified.sol";
-import { IReverseRegistrar } from "@rns-contracts/interfaces/IReverseRegistrar.sol";
+import { INSUnified } from "../INSUnified.sol";
+import { INSReverseRegistrar } from "../INSReverseRegistrar.sol";
 import { IABIResolver } from "./IABIResolver.sol";
 import { IAddressResolver } from "./IAddressResolver.sol";
 import { IContentHashResolver } from "./IContentHashResolver.sol";
@@ -48,7 +48,7 @@ interface IPublicResolver is
   /**
    * @dev Retrieves the reverse registrar associated with this resolver.
    */
-  function getReverseRegistrar() external view returns (IReverseRegistrar);
+  function getReverseRegistrar() external view returns (INSReverseRegistrar);
 
   /**
    * @dev This function provides an extra security check when called from privileged contracts (such as

--- a/src/libraries/LibRNSDomain.sol
+++ b/src/libraries/LibRNSDomain.sol
@@ -1,9 +1,11 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 library LibRNSDomain {
   /// @dev Value equals to namehash('ron')
   uint256 internal constant RON_ID = 0xba69923fa107dbf5a25a073a10b7c9216ae39fbadc95dc891d460d9ae315d688;
+  /// @dev Value equals to namehash('addr.reverse')
+  uint256 internal constant ADDR_REVERSE_ID = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
   /**
    * @dev Calculate the corresponding id given parentId and label.
@@ -16,40 +18,12 @@ library LibRNSDomain {
     }
   }
 
+  /**
+   * @dev Calculates the hash of the label.
+   */
   function hashLabel(string memory label) internal pure returns (bytes32 hashed) {
     assembly ("memory-safe") {
       hashed := keccak256(add(label, 32), mload(label))
-    }
-  }
-
-  /**
-   * @dev Returns the length of a given string
-   *
-   * @param s The string to measure the length of
-   * @return The length of the input string
-   */
-  function strlen(string memory s) internal pure returns (uint256) {
-    unchecked {
-      uint256 i;
-      uint256 len;
-      uint256 bytelength = bytes(s).length;
-      for (len; i < bytelength; len++) {
-        bytes1 b = bytes(s)[i];
-        if (b < 0x80) {
-          i += 1;
-        } else if (b < 0xE0) {
-          i += 2;
-        } else if (b < 0xF0) {
-          i += 3;
-        } else if (b < 0xF8) {
-          i += 4;
-        } else if (b < 0xFC) {
-          i += 5;
-        } else {
-          i += 6;
-        }
-      }
-      return len;
     }
   }
 }

--- a/src/libraries/LibString.sol
+++ b/src/libraries/LibString.sol
@@ -1,13 +1,43 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-library LibStrAddrConvert {
+library LibString {
   error InvalidStringLength();
   error InvalidCharacter(bytes1 char);
 
   /// @dev Lookup constant for method. See more detail at https://eips.ethereum.org/EIPS/eip-181
-
   bytes32 private constant LOOKUP = 0x3031323334353637383961626364656600000000000000000000000000000000;
+
+  /**
+   * @dev Returns the length of a given string
+   *
+   * @param s The string to measure the length of
+   * @return The length of the input string
+   */
+  function strlen(string memory s) internal pure returns (uint256) {
+    unchecked {
+      uint256 i;
+      uint256 len;
+      uint256 bytelength = bytes(s).length;
+      for (len; i < bytelength; len++) {
+        bytes1 b = bytes(s)[i];
+        if (b < 0x80) {
+          i += 1;
+        } else if (b < 0xE0) {
+          i += 2;
+        } else if (b < 0xF0) {
+          i += 3;
+        } else if (b < 0xF8) {
+          i += 4;
+        } else if (b < 0xFC) {
+          i += 5;
+        } else {
+          i += 6;
+        }
+      }
+      return len;
+    }
+  }
 
   /**
    * @dev Converts an address to string.
@@ -38,8 +68,8 @@ library LibStrAddrConvert {
       uint160 addr;
       for (uint256 i = 0; i < 40; i += 2) {
         addr *= 0x100;
-        addr += uint160(_hexCharToDec(bytes(stringifiedAddr)[i])) * 0x10;
-        addr += _hexCharToDec(bytes(stringifiedAddr)[i + 1]);
+        addr += uint160(hexCharToDec(bytes(stringifiedAddr)[i])) * 0x10;
+        addr += hexCharToDec(bytes(stringifiedAddr)[i + 1]);
       }
       return address(addr);
     }
@@ -49,7 +79,7 @@ library LibStrAddrConvert {
    * @dev Converts a hex char (0-9, a-f, A-F) to decimal number.
    * Reverts if the char is invalid.
    */
-  function _hexCharToDec(bytes1 c) private pure returns (uint8 r) {
+  function hexCharToDec(bytes1 c) private pure returns (uint8 r) {
     unchecked {
       if ((bytes1("a") <= c) && (c <= bytes1("f"))) r = uint8(c) - 87;
       else if ((bytes1("A") <= c) && (c <= bytes1("F"))) r = uint8(c) - 55;

--- a/src/resolvers/PublicResolver.sol
+++ b/src/resolvers/PublicResolver.sol
@@ -40,7 +40,7 @@ contract PublicResolver is
   INSUnified internal _rnsUnified;
 
   /// @dev The reverse registrar contract
-  IReverseRegistrar internal _reverseRegistrar;
+  INSReverseRegistrar internal _reverseRegistrar;
 
   modifier onlyAuthorized(bytes32 node) {
     _requireAuthorized(node, msg.sender);
@@ -51,7 +51,7 @@ contract PublicResolver is
     _disableInitializers();
   }
 
-  function initialize(INSUnified rnsUnified, IReverseRegistrar reverseRegistrar) external initializer {
+  function initialize(INSUnified rnsUnified, INSReverseRegistrar reverseRegistrar) external initializer {
     _rnsUnified = rnsUnified;
     _reverseRegistrar = reverseRegistrar;
   }
@@ -84,7 +84,7 @@ contract PublicResolver is
   }
 
   /// @inheritdoc IPublicResolver
-  function getReverseRegistrar() external view returns (IReverseRegistrar) {
+  function getReverseRegistrar() external view returns (INSReverseRegistrar) {
     return _reverseRegistrar;
   }
 
@@ -175,7 +175,7 @@ contract PublicResolver is
 
   /// @dev Override {INameResolver-name}.
   function name(bytes32 node) public view virtual override(INameResolver, NameResolvable) returns (string memory) {
-    address reversedAddress = _reverseRegistrar.getAddress(node);
+    address reversedAddress = _reverseRegistrar.getAddress(uint256(node));
     string memory domainName = super.name(node);
     uint256 tokenId = uint256(_rnsUnified.namehash(domainName));
     return _rnsUnified.ownerOf(tokenId) == reversedAddress ? domainName : "";

--- a/test/libraries/LibString.StrAddrConvert.t.sol
+++ b/test/libraries/LibString.StrAddrConvert.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "src/libraries/LibStrAddrConvert.sol";
+import { Test } from "forge-std/Test.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { LibString } from "@rns-contracts/libraries/LibString.sol";
 
-contract LibStrAddrConvertTest is Test {
+contract LibString_StrAddrConvert_Test is Test {
   function test_AddressToString(address addr) public {
     string memory expected = withoutHexPrefix(Strings.toHexString(addr));
-    string memory actual = LibStrAddrConvert.toString(addr);
+    string memory actual = LibString.toString(addr);
     assertEq(expected, actual);
   }
 
   function test_StringToAddress(address expected) public {
     string memory stringifiedAddr = withoutHexPrefix(Strings.toHexString(expected));
-    address actual = LibStrAddrConvert.parseAddr(stringifiedAddr);
+    address actual = LibString.parseAddr(stringifiedAddr);
     assertEq(expected, actual);
   }
 


### PR DESCRIPTION
### Description
This PR provides refactor `RNSReverseRegistrar`.
### Changes
#### Interface Changes
- `getAddress(bytes32)` -> `getAddress(uint256)`
- `computeNode(bytes32)` -> `computeId(uint256)`
#### Logic Changes
- Use relative import instead of remapping import.
- require `RNSReverseRegistrar` is `ownerOf(ADDR_REVERSE_ID) || isApprovedForAll(ADDR_REVERS_ID) || getApproved(ADDR_REVERSE_ID)` instead of `ownerOf(ADDR_REVERSE_ID)`
- Move `parseAddr` and `toString` to `LibRNSDomain`.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
