### PR TITLE
feat: return tax price in `RNSDomainPrice`

### DIFF
--- a/src/RNSDomainPrice.sol
+++ b/src/RNSDomainPrice.sol
@@ -240,25 +240,25 @@ contract RNSDomainPrice is Initializable, AccessControlEnumerable, INSDomainPric
   function getRenewalFee(string memory label, uint256 duration)
     public
     view
-    returns (uint256 usdPrice, uint256 ronPrice, uint256 usdTax, uint256 ronTax)
+    returns (UnitPrice memory basePrice, UnitPrice memory tax)
   {
     uint256 nameLen = label.strlen();
     bytes32 lbHash = label.hashLabel();
     uint256 overriddenRenewalFee = _rnFeeOverriding[lbHash];
 
     if (overriddenRenewalFee != 0) {
-      usdPrice = duration * ~overriddenRenewalFee;
+      basePrice.usd = duration * ~overriddenRenewalFee;
     } else {
       uint256 renewalFeeByLength = _rnFee[Math.min(nameLen, _rnfMaxLength)];
-      usdPrice = duration * renewalFeeByLength;
+      basePrice.usd = duration * renewalFeeByLength;
       // tax is added of name is reserved for auction
       if (_auction.reserved(LibRNSDomain.toId(LibRNSDomain.RON_ID, label))) {
-        usdTax = Math.mulDiv(_taxRatio, _getDomainPrice(lbHash), MAX_PERCENTAGE);
+        tax.usd = Math.mulDiv(_taxRatio, _getDomainPrice(lbHash), MAX_PERCENTAGE);
       }
     }
 
-    ronTax = convertUSDToRON(usdTax);
-    ronPrice = convertUSDToRON(usdPrice);
+    tax.ron = convertUSDToRON(tax.usd);
+    basePrice.ron = convertUSDToRON(basePrice.usd);
   }
 
   /**

--- a/src/interfaces/INSDomainPrice.sol
+++ b/src/interfaces/INSDomainPrice.sol
@@ -13,6 +13,11 @@ interface INSDomainPrice {
     uint256 fee;
   }
 
+  struct UnitPrice {
+    uint256 usd;
+    uint256 ron;
+  }
+
   /// @dev Emitted when the renewal reservation ratio is updated.
   event TaxRatioUpdated(address indexed operator, uint256 indexed ratio);
   /// @dev Emitted when the maximum length of renewal fee is updated.
@@ -111,7 +116,7 @@ interface INSDomainPrice {
   function getRenewalFee(string calldata label, uint256 duration)
     external
     view
-    returns (uint256 usdPrice, uint256 ronPrice, uint256 usdTax, uint256 ronTax);
+    returns (UnitPrice memory basePrice, UnitPrice memory tax);
 
   /**
    * @dev Returns the renewal fee of a label. Reverts if not overridden.


### PR DESCRIPTION
### Description
This feature allow return tax for function `getRenewalFee(string,uint64)`.
Task: https://sky-mavis.slack.com/archives/C05D6TP19TK/p1696841576323389?thread_ts=1696836094.601249&cid=C05D6TP19TK
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
