### PR TITLE
chore: pull lasest features from 'release-testnet/v0.2.0' into feature/auction

### DIFF
--- a/src/RNSDomainPrice.sol
+++ b/src/RNSDomainPrice.sol
@@ -67,7 +67,7 @@ contract RNSDomainPrice is Initializable, AccessControlEnumerable, INSDomainPric
     bytes32 pythIdForRONUSD
   ) external initializer {
     uint256 length = operators.length;
-    bytes32 operatorRole;
+    bytes32 operatorRole = OPERATOR_ROLE;
 
     for (uint256 i; i < length;) {
       _setupRole(operatorRole, operators[i]);


### PR DESCRIPTION
### Description
This PR pull latest feature from 'release-testnet/v0.2.0' into feature/auction.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
