### PR TITLE
Fix/require live/reverse registrar

### DIFF
--- a/src/RNSReverseRegistrar.sol
+++ b/src/RNSReverseRegistrar.sol
@@ -148,8 +148,10 @@ contract RNSReverseRegistrar is Initializable, Ownable, INSReverseRegistrar {
     uint256 addrReverseId = LibRNSDomain.ADDR_REVERSE_ID;
     address owner = rnsUnified.ownerOf(addrReverseId);
     if (
-      owner == address(this) || rnsUnified.getApproved(addrReverseId) == address(this)
-        || rnsUnified.isApprovedForAll(owner, address(this))
+      !(
+        owner == address(this) || rnsUnified.getApproved(addrReverseId) == address(this)
+          || rnsUnified.isApprovedForAll(owner, address(this))
+      )
     ) {
       revert InvalidConfig();
     }


### PR DESCRIPTION
### Description
This PR fixes wrong logic in `RNSReverseRegistrar::_requireLive`
2nd attempt of #58 
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
