### PR TITLE
feat: add auction domain expiry check to RNSDomainPrice

### DIFF
--- a/src/interfaces/INSDomainPrice.sol
+++ b/src/interfaces/INSDomainPrice.sol
@@ -7,6 +7,7 @@ import { IPyth } from "@pythnetwork/IPyth.sol";
 interface INSDomainPrice {
   error InvalidArrayLength();
   error RenewalFeeIsNotOverriden();
+  error ExceedAuctionDomainExpiry();
 
   struct RenewalFee {
     uint256 labelLength;
@@ -38,6 +39,11 @@ interface INSDomainPrice {
   event PythOracleConfigUpdated(
     address indexed operator, IPyth indexed pyth, uint256 maxAcceptableAge, bytes32 indexed pythIdForRONUSD
   );
+
+   /**
+   * @dev The maximum expiry duration of a domain after transferring to bidder.
+   */
+  function MAX_AUCTION_DOMAIN_EXPIRY() external pure returns (uint64);
 
   /**
    * @dev Returns the Pyth oracle config.


### PR DESCRIPTION
### Description
This pull request introduces a restriction, limiting the domain's maximum auction listing duration to three years.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
