### PR TITLE
feat: add prelaunch config migration scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/foundry-deployment-kit"]
 	path = lib/foundry-deployment-kit
 	url = https://github.com/axieinfinity/foundry-deployment-kit
+[submodule "lib/migration-20231015"]
+	path = lib/migration-20231015
+	url = https://github.com/axieinfinity/rns-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "lib/migration-20231020"]
 	path = lib/migration-20231020
 	url = https://github.com/axieinfinity/rns-contracts
+[submodule "lib/migration-20231024"]
+	path = lib/migration-20231024
+	url = https://github.com/axieinfinity/rns-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "lib/migration-20231015"]
 	path = lib/migration-20231015
 	url = https://github.com/axieinfinity/rns-contracts
+[submodule "lib/migration-20231020"]
+	path = lib/migration-20231020
+	url = https://github.com/axieinfinity/rns-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/migration-20231024"]
 	path = lib/migration-20231024
 	url = https://github.com/axieinfinity/rns-contracts
+[submodule "lib/migration-20231025"]
+	path = lib/migration-20231025
+	url = https://github.com/axieinfinity/rns-contracts

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 verify_arg=""
 extra_argument=""
-op_command=""
+op_command="op run --env-file="./.env" --"
 
 for arg in "$@"; do
     case $arg in

--- a/script/20231106-config-prelaunch/20231106_RevertRenewalFees.s.sol
+++ b/script/20231106-config-prelaunch/20231106_RevertRenewalFees.s.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ContractKey } from "foundry-deployment-kit/configs/ContractConfig.sol";
+import { RNSDeploy } from "script/RNSDeploy.s.sol";
+import { RNSDomainPrice } from "@rns-contracts/RNSDomainPrice.sol";
+
+contract Migration__20231106_RevertRenewalFees is RNSDeploy {
+  function run() public {
+    RNSDomainPrice domainPrice = RNSDomainPrice(_config.getAddressFromCurrentNetwork(ContractKey.RNSDomainPrice));
+
+    Config memory config = getConfig();
+    vm.broadcast(domainPrice.getRoleMember(domainPrice.DEFAULT_ADMIN_ROLE(), 0));
+    domainPrice.setRenewalFeeByLengths(config.renewalFees);
+  }
+}

--- a/script/20231106-config-prelaunch/20231106_RevertRenewalFees.s.sol
+++ b/script/20231106-config-prelaunch/20231106_RevertRenewalFees.s.sol
@@ -11,6 +11,8 @@ contract Migration__20231106_RevertRenewalFees is RNSDeploy {
 
     Config memory config = getConfig();
     vm.broadcast(domainPrice.getRoleMember(domainPrice.DEFAULT_ADMIN_ROLE(), 0));
+    vm.resumeGasMetering();
     domainPrice.setRenewalFeeByLengths(config.renewalFees);
+    vm.pauseGasMetering(); 
   }
 }

--- a/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
+++ b/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
@@ -23,10 +23,14 @@ contract Migration__20231106_SubmitReservedNames is RNSDeploy {
     address ronOwner = rns.ownerOf(LibRNSDomain.RON_ID);
 
     vm.broadcast(ronOwner);
+    vm.resumeGasMetering();
     rns.setApprovalForAll(address(multicall), true);
+    vm.pauseGasMetering();
 
     vm.broadcast(_config.getSender());
+    vm.resumeGasMetering();
     multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);
+    vm.pauseGasMetering();
   }
 
   function _parseData(string memory path) internal view returns (address[] memory tos, string[] memory labels) {

--- a/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
+++ b/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { console2 } from "forge-std/console2.sol";
+import { ContractKey } from "foundry-deployment-kit/configs/ContractConfig.sol";
+import { JSONParserLib } from "solady/utils/JSONParserLib.sol";
+import { RNSDeploy } from "script/RNSDeploy.s.sol";
+import { LibRNSDomain, RNSUnified } from "@rns-contracts/RNSUnified.sol";
+import { OwnedMulticaller, OwnedMulticallerDeploy } from "script/contracts/OwnedMulticallerDeploy.s.sol";
+
+contract Migration__20231106_SubmitReservedNames is RNSDeploy {
+  using JSONParserLib for *;
+  using JSONParserLib for JSONParserLib.Item;
+
+  function run() public {
+    string memory raw = vm.readFile("script/20231106-script/data/mock.json");
+    console2.log("raw", raw);
+    JSONParserLib.Item memory reservedNames = raw.parse().at('"reservedNames"');
+    uint256 length = reservedNames.size();
+
+    console2.log("length", length);
+
+    address[] memory tos = new address[](length);
+    string[] memory labels = new string[](length);
+
+    for (uint256 i; i < length; ++i) {
+      tos[i] = vm.parseAddress(reservedNames.at(i).at('"address"').value().decodeString());
+      labels[i] = reservedNames.at(i).at('"label"').value().decodeString();
+
+      console2.log("tos:", i, tos[i]);
+      console2.log("labels:", i, labels[i]);
+    }
+
+    uint64 duration = uint64(365 days);
+    OwnedMulticaller multicall = new OwnedMulticallerDeploy().run();
+    RNSUnified rns = RNSUnified(_config.getAddressFromCurrentNetwork(ContractKey.RNSUnified));
+    address resolver = _config.getAddressFromCurrentNetwork(ContractKey.PublicResolver);
+
+    address ronOwner = rns.ownerOf(LibRNSDomain.RON_ID);
+
+    vm.startBroadcast(ronOwner);
+    rns.approve(address(multicall), LibRNSDomain.RON_ID);
+    multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);
+    vm.stopBroadcast();
+  }
+}

--- a/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
+++ b/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
@@ -11,7 +11,7 @@ import { OwnedMulticaller, OwnedMulticallerDeploy } from "script/contracts/Owned
 contract Migration__20231106_SubmitReservedNames is RNSDeploy {
   using JSONParserLib for *;
 
-  function run() public {
+  function run() public trySetUp {
     (address[] memory tos, string[] memory labels) = _parseData("script/20231106-config-prelaunch/data/test.json");
 
     // default duration is 1 year
@@ -21,9 +21,9 @@ contract Migration__20231106_SubmitReservedNames is RNSDeploy {
     RNSUnified rns = RNSUnified(_config.getAddressFromCurrentNetwork(ContractKey.RNSUnified));
     address resolver = _config.getAddressFromCurrentNetwork(ContractKey.PublicResolver);
     address ronOwner = rns.ownerOf(LibRNSDomain.RON_ID);
-    
+
     vm.broadcast(ronOwner);
-    rns.approve(address(multicall), LibRNSDomain.RON_ID);
+    rns.setApprovalForAll(address(multicall), true);
 
     vm.broadcast(_config.getSender());
     multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);

--- a/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
+++ b/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ContractKey } from "foundry-deployment-kit/configs/ContractConfig.sol";
+import { console2 } from "forge-std/console2.sol";
+import { RNSDeploy } from "script/RNSDeploy.s.sol";
+import { RNSUnified } from "@rns-contracts/RNSUnified.sol";
+import { OwnedMulticallerDeploy } from "script/contracts/OwnedMulticallerDeploy.s.sol";
+import { OwnedMulticaller } from "@rns-contracts/utils/OwnedMulticaller.sol";
+import { LibRNSDomain } from "@rns-contracts/libraries/LibRNSDomain.sol";
+
+contract Migration__20231106_TransferOwnership is RNSDeploy {
+  function _injectDependencies() internal virtual override {
+    _setDependencyDeployScript(ContractKey.OwnedMulticaller, new OwnedMulticallerDeploy());
+  }
+
+  function run() public trySetUp {
+    // fill in original owner
+    address originalOwner = _config.getSender();
+
+    RNSUnified rns = RNSUnified(_config.getAddressFromCurrentNetwork(ContractKey.RNSUnified));
+    OwnedMulticaller multicall = OwnedMulticaller(loadContractOrDeploy(ContractKey.OwnedMulticaller));
+    address auction = _config.getAddressFromCurrentNetwork(ContractKey.RNSAuction);
+    address ronController = _config.getAddressFromCurrentNetwork(ContractKey.RONRegistrarController);
+    address reverseRegistrar = _config.getAddressFromCurrentNetwork(ContractKey.RNSReverseRegistrar);
+
+    uint256 reverseId = uint256(LibRNSDomain.namehash("reverse"));
+    console2.log("reverseId", reverseId);
+    uint256 addrReverseId = uint256(LibRNSDomain.namehash("addr.reverse"));
+    console2.log("reverse.addr id", addrReverseId);
+
+    address currentOwner = rns.ownerOf(LibRNSDomain.RON_ID);
+    assertEq(currentOwner, rns.ownerOf(reverseId), "currentOwner != rns.ownerOf(reverseId)");
+    assertEq(currentOwner, rns.ownerOf(addrReverseId), "currentOwner != rns.ownerOf(addrReverseId)");
+    
+    // approve for owned-multicall contract
+    vm.prank(currentOwner);
+    rns.setApprovalForAll(address(multicall), true);
+
+    uint256[] memory values = new uint256[](3);
+    address[] memory targets = new address[](3);
+    targets[0] = targets[1] = targets[2] = address(rns);
+    bytes[] memory callDatas = new bytes[](3);
+    // transfer addr.reverse id to original owner
+    callDatas[0] = abi.encodeCall(rns.transferFrom, (currentOwner, originalOwner, addrReverseId));
+    // transfer .reverse id to original owner
+    callDatas[1] = abi.encodeCall(rns.transferFrom, (currentOwner, originalOwner, reverseId));
+    // transfer .ron id to original owner
+    callDatas[2] = abi.encodeCall(rns.transferFrom, (currentOwner, originalOwner, LibRNSDomain.RON_ID));
+
+    vm.prank(multicall.owner());
+    multicall.multicall(targets, callDatas, values);
+
+    // re-approve for owned-multicall contract
+    vm.prank(originalOwner);
+    rns.setApprovalForAll(address(multicall), true);
+
+    callDatas[0] = abi.encodeCall(rns.setApprovalForAll, (auction, true));
+    callDatas[1] = abi.encodeCall(rns.setApprovalForAll, (ronController, true));
+    callDatas[2] = abi.encodeCall(rns.approve, (reverseRegistrar, addrReverseId));
+
+    vm.prank(multicall.owner());
+    multicall.multicall(targets, callDatas, values);
+  }
+}

--- a/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
+++ b/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
@@ -32,7 +32,7 @@ contract Migration__20231106_TransferOwnership is RNSDeploy {
     address currentOwner = rns.ownerOf(LibRNSDomain.RON_ID);
     assertEq(currentOwner, rns.ownerOf(reverseId), "currentOwner != rns.ownerOf(reverseId)");
     assertEq(currentOwner, rns.ownerOf(addrReverseId), "currentOwner != rns.ownerOf(addrReverseId)");
-    
+
     // approve for owned-multicall contract
     vm.prank(currentOwner);
     rns.setApprovalForAll(address(multicall), true);

--- a/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
+++ b/script/20231106-config-prelaunch/20231106_TransferOwnership.s.sol
@@ -51,15 +51,23 @@ contract Migration__20231106_TransferOwnership is RNSDeploy {
     vm.prank(multicall.owner());
     multicall.multicall(targets, callDatas, values);
 
-    // re-approve for owned-multicall contract
-    vm.prank(originalOwner);
-    rns.setApprovalForAll(address(multicall), true);
+    vm.startPrank(originalOwner);
+    rns.setApprovalForAll(address(auction), true);
+    rns.setApprovalForAll(address(ronController), true);
+    rns.approve(address(reverseRegistrar), addrReverseId);
+    vm.stopPrank();
 
-    callDatas[0] = abi.encodeCall(rns.setApprovalForAll, (auction, true));
-    callDatas[1] = abi.encodeCall(rns.setApprovalForAll, (ronController, true));
-    callDatas[2] = abi.encodeCall(rns.approve, (reverseRegistrar, addrReverseId));
-
-    vm.prank(multicall.owner());
-    multicall.multicall(targets, callDatas, values);
+    assertTrue(
+      rns.isApprovedForAll(originalOwner, address(auction)), "!rns.isApprovedForAll(originalOwner, address(auction))"
+    );
+    assertEq(
+      rns.getApproved(addrReverseId),
+      address(reverseRegistrar),
+      "!rns.getApproved(addrReverseId), address(reverseRegistrar)"
+    );
+    assertTrue(
+      rns.isApprovedForAll(originalOwner, address(ronController)),
+      "!rns.isApprovedForAll(originalOwner, address(ronController))"
+    );
   }
 }

--- a/script/20231106-config-prelaunch/data/mock.json
+++ b/script/20231106-config-prelaunch/data/mock.json
@@ -1,0 +1,12 @@
+{
+    "reservedNames": [
+        {
+            "label": "duke",
+            "address": "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+        },
+        {
+            "label": "duke1",
+            "address": "0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF"
+        }
+    ]
+}

--- a/script/20231106-config-prelaunch/data/test.json
+++ b/script/20231106-config-prelaunch/data/test.json
@@ -1,0 +1,32 @@
+{
+    "reservedNames": [
+        {
+            "label": "rnstesting1",
+            "address": "0xbf99983f7f2b87169e80d33c8ef74a0437558b97"
+        },
+        {
+            "label": "rnstesting2",
+            "address": "0xbf99983f7f2b87169e80d33c8ef74a0437558b97"
+        },
+        {
+            "label": "rnstesting3",
+            "address": "0xbf99983f7f2b87169e80d33c8ef74a0437558b97"
+        },
+        {
+            "label": "rnstesting4",
+            "address": "0xbf99983f7f2b87169e80d33c8ef74a0437558b97"
+        },
+        {
+            "label": "rnstesting5",
+            "address": "0xbf99983f7f2b87169e80d33c8ef74a0437558b97"
+        },
+        {
+            "label": "rnstesting9",
+            "address": "0xd115a29bdf33f6db712dc514721fbfa9b522505c"
+        },
+        {
+            "label": "rnstesting10",
+            "address": "0xd115a29bdf33f6db712dc514721fbfa9b522505c"
+        }
+    ]
+}

--- a/script/contracts/OwnedMulticallerDeploy.s.sol
+++ b/script/contracts/OwnedMulticallerDeploy.s.sol
@@ -1,17 +1,17 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity ^0.8.19;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
 
-// import { BaseDeploy, ContractKey } from "foundry-deployment-kit/BaseDeploy.s.sol";
-// import { OwnedMulticaller } from "@rns-contracts/utils/OwnedMulticaller.sol";
-// import { RNSDeploy } from "../RNSDeploy.s.sol";
+import { BaseDeploy, ContractKey } from "foundry-deployment-kit/BaseDeploy.s.sol";
+import { OwnedMulticaller } from "@rns-contracts/utils/OwnedMulticaller.sol";
+import { RNSDeploy } from "../RNSDeploy.s.sol";
 
-// contract OwnedMulticallerDeploy is RNSDeploy {
-//   function _defaultArguments() internal virtual override returns (bytes memory args) {
-//     Config memory config = getConfig();
-//     args = abi.encodeCall(NameChecker.initialize, (config.admin, config.minWord, config.maxWord));
-//   }
+contract OwnedMulticallerDeploy is RNSDeploy {
+  function _defaultArguments() internal virtual override returns (bytes memory args) {
+    Config memory config = getConfig();
+    args = abi.encode(config.admin);
+  }
 
-//   function run() public virtual trySetUp returns (OwnedMulticaller) {
-//     return NameChecker(_deployImmutable(ContractKey.NameChecker));
-//   }
-// }
+  function run() public virtual trySetUp returns (OwnedMulticaller) {
+    return OwnedMulticaller(_deployImmutable(ContractKey.OwnedMulticaller));
+  }
+}

--- a/script/contracts/OwnedMulticallerDeploy.s.sol
+++ b/script/contracts/OwnedMulticallerDeploy.s.sol
@@ -7,8 +7,7 @@ import { RNSDeploy } from "../RNSDeploy.s.sol";
 
 contract OwnedMulticallerDeploy is RNSDeploy {
   function _defaultArguments() internal virtual override returns (bytes memory args) {
-    Config memory config = getConfig();
-    args = abi.encode(config.admin);
+    args = abi.encode(_config.getSender());
   }
 
   function run() public virtual trySetUp returns (OwnedMulticaller) {

--- a/src/utils/OwnedMulticaller.sol
+++ b/src/utils/OwnedMulticaller.sol
@@ -8,7 +8,10 @@ import { ErrorHandler } from "../libraries/ErrorHandler.sol";
 contract OwnedMulticaller is Ownable {
   using ErrorHandler for bool;
 
-  constructor() Ownable() { }
+  constructor(address owner_) {
+    require(owner_ != address(0), "owner_ == address(0x0)");
+    _transferOwnership(owner_);
+  }
 
   function kill() external onlyOwner {
     selfdestruct(payable(_msgSender()));


### PR DESCRIPTION
### Description
This PR mainly adds 3 scripts for upcoming RNS mainnet release:
- Bulk submit reserved names script.
- Transfer ownership script.
- Revert renewal fees.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
