### PR TITLE
fix(RONRegistrarController): emit event `TreasuryUpdated` when setting treasury in `RONRegistrarController` contract.

### DIFF
--- a/src/RONRegistrarController.sol
+++ b/src/RONRegistrarController.sol
@@ -92,8 +92,8 @@ contract RONRegistrarController is
     _setPriceOracle(priceOracle);
     _setMinRegistrationDuration(minRegistrationDuration);
     _setCommitmentAge(minCommitmentAge, maxCommitmentAge);
+    _setTreasury(treasury);
 
-    _treasury = treasury;
     _rnsUnified = rnsUnified;
     _nameChecker = nameChecker;
     _reverseRegistrar = reverseRegistrar;
@@ -281,7 +281,7 @@ contract RONRegistrarController is
    * @inheritdoc IRONRegistrarController
    */
   function setTreasury(address payable addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    _treasury = addr;
+    _setTreasury(addr);
   }
 
   /**
@@ -450,6 +450,19 @@ contract RONRegistrarController is
   function _setPriceOracle(INSDomainPrice priceOracle) internal {
     _priceOracle = priceOracle;
     emit DomainPriceUpdated(_msgSender(), priceOracle);
+  }
+
+  /**
+   * @dev Helper method to update treasury address.
+   *
+   * Emits an event {TreasuryUpdated}.
+   */
+  function _setTreasury(address payable addr) internal {
+    if (addr == address(0x0)) revert NullAddress();
+
+    _treasury = addr;
+
+    emit TreasuryUpdated(addr);
   }
 
   /**

--- a/src/interfaces/IRONRegistrarController.sol
+++ b/src/interfaces/IRONRegistrarController.sol
@@ -38,6 +38,8 @@ interface IRONRegistrarController {
   error ErrInvalidRegisterProtectedName(string name, address requestOwner, bool nameProtected, bool ownerWhitelisted);
   /// @dev Thrown when received invalid array length
   error InvalidArrayLength();
+  /// @dev Thrown when treasury address is set to null
+  error NullAddress();
 
   /**
    * @dev Emitted when the min registration duration is updated.
@@ -45,6 +47,9 @@ interface IRONRegistrarController {
    * @param duration The new duration in seconds.
    */
   event MinRegistrationDurationUpdated(address indexed operator, uint256 duration);
+
+  /// @dev Emitted when the treasury is updated.
+  event TreasuryUpdated(address indexed addr);
 
   /**
    * @dev Emitted when RNSDomainPrice contract is updated.


### PR DESCRIPTION
### Description
This PR simply allow emitting event `TreasuryUpdated` when setting treasury address in `RONRegistrarController` contract.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
