### PR TITLE
fix(OwnedMulticaller): remove multiMint, kill fn

### DIFF
--- a/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
+++ b/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
@@ -31,17 +31,6 @@ contract Migration__20231106_SubmitReservedNames is Migration {
     // mintBatch(multicall, duration, rns, resolver, tos, labels);
   }
 
-  // function mintBatch(
-  //   OwnedMulticaller multicall,
-  //   uint64 duration,
-  //   RNSUnified rns,
-  //   address resolver,
-  //   address[] memory tos,
-  //   string[] memory labels
-  // ) public {
-  //   vm.broadcast(config.getSender());
-  //   multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);
-  // }
 
   function _parseData(string memory path) internal view returns (address[] memory tos, string[] memory labels) {
     string memory raw = vm.readFile(path);

--- a/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
+++ b/script/20231106-config-prelaunch/20231106_SubmitReservedNames.s.sol
@@ -28,20 +28,20 @@ contract Migration__20231106_SubmitReservedNames is Migration {
     address[] memory tos;
     string[] memory labels;
     (tos, labels) = _parseData("./script/20231106-param-prelaunch/data/finalReservedNames.json");
-    mintBatch(multicall, duration, rns, resolver, tos, labels);
+    // mintBatch(multicall, duration, rns, resolver, tos, labels);
   }
 
-  function mintBatch(
-    OwnedMulticaller multicall,
-    uint64 duration,
-    RNSUnified rns,
-    address resolver,
-    address[] memory tos,
-    string[] memory labels
-  ) public {
-    vm.broadcast(config.getSender());
-    multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);
-  }
+  // function mintBatch(
+  //   OwnedMulticaller multicall,
+  //   uint64 duration,
+  //   RNSUnified rns,
+  //   address resolver,
+  //   address[] memory tos,
+  //   string[] memory labels
+  // ) public {
+  //   vm.broadcast(config.getSender());
+  //   multicall.multiMint(rns, LibRNSDomain.RON_ID, resolver, duration, tos, labels);
+  // }
 
   function _parseData(string memory path) internal view returns (address[] memory tos, string[] memory labels) {
     string memory raw = vm.readFile(path);

--- a/src/utils/OwnedMulticaller.sol
+++ b/src/utils/OwnedMulticaller.sol
@@ -9,21 +9,8 @@ contract OwnedMulticaller is Ownable {
   using ErrorHandler for bool;
 
   constructor(address owner_) {
-    require(owner_ != address(0), "owner_ == address(0x0)");
+    require(owner_ != address(0), "OwnedMulticaller: owner_ is null");
     _transferOwnership(owner_);
-  }
-
-  function multiMint(
-    INSUnified rns,
-    uint256 parentId,
-    address resolver,
-    uint64 duration,
-    address[] calldata tos,
-    string[] calldata labels
-  ) external onlyOwner {
-    for (uint256 i; i < labels.length; ++i) {
-      rns.mint(parentId, labels[i], resolver, tos[i], duration);
-    }
   }
 
   function multicall(address[] calldata tos, bytes[] calldata callDatas, uint256[] calldata values)
@@ -33,7 +20,7 @@ contract OwnedMulticaller is Ownable {
     returns (bool[] memory results, bytes[] memory returnDatas)
   {
     uint256 length = tos.length;
-    require(length == callDatas.length && length == values.length, "invalid length");
+    require(length == callDatas.length && length == values.length, "OwnedMulticaller: mismatch length");
     results = new bool[](length);
     returnDatas = new bytes[](length);
 

--- a/src/utils/OwnedMulticaller.sol
+++ b/src/utils/OwnedMulticaller.sol
@@ -2,17 +2,28 @@
 pragma solidity ^0.8.19;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { INSUnified } from "../interfaces/INSUnified.sol";
 import { ErrorHandler } from "../libraries/ErrorHandler.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import { IERC1155Receiver } from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
-contract OwnedMulticaller is Ownable {
+contract OwnedMulticaller is Ownable, IERC721Receiver, IERC1155Receiver {
   using ErrorHandler for bool;
 
   constructor(address owner_) {
     require(owner_ != address(0), "OwnedMulticaller: owner_ is null");
+
     _transferOwnership(owner_);
   }
 
+  /**
+   * @dev Execute multiple calls in a single transaction.
+   * @param tos The addresses to call.
+   * @param callDatas The call data for each call.
+   * @param values The value to send for each call.
+   * @return results The results of each call.
+   * @return returnDatas The return data of each call.
+   */
   function multicall(address[] calldata tos, bytes[] calldata callDatas, uint256[] calldata values)
     external
     payable
@@ -28,5 +39,38 @@ contract OwnedMulticaller is Ownable {
       (results[i], returnDatas[i]) = tos[i].call{ value: values[i] }(callDatas[i]);
       results[i].handleRevert(returnDatas[i]);
     }
+  }
+
+  /**
+   * @dev See {IERC165-supportsInterface}.
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+    return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721Receiver).interfaceId
+      || interfaceId == type(IERC1155Receiver).interfaceId;
+  }
+
+  /**
+   * @dev See {IERC721Receiver-onERC721Received}.
+   */
+  function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+    return msg.sig;
+  }
+
+  /**
+   * @dev See {IERC1155Receiver-onERC1155Received}.
+   */
+  function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+    external
+    pure
+    returns (bytes4)
+  {
+    return msg.sig;
+  }
+
+  /**
+   * @dev See {IERC1155Receiver-onERC1155Received}.
+   */
+  function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+    return msg.sig;
   }
 }

--- a/src/utils/OwnedMulticaller.sol
+++ b/src/utils/OwnedMulticaller.sol
@@ -13,10 +13,6 @@ contract OwnedMulticaller is Ownable {
     _transferOwnership(owner_);
   }
 
-  function kill() external onlyOwner {
-    selfdestruct(payable(_msgSender()));
-  }
-
   function multiMint(
     INSUnified rns,
     uint256 parentId,
@@ -36,11 +32,12 @@ contract OwnedMulticaller is Ownable {
     onlyOwner
     returns (bool[] memory results, bytes[] memory returnDatas)
   {
-    require(tos.length == callDatas.length && tos.length == values.length, "invalid length");
-    results = new bool[](tos.length);
-    returnDatas = new bytes[](tos.length);
+    uint256 length = tos.length;
+    require(length == callDatas.length && length == values.length, "invalid length");
+    results = new bool[](length);
+    returnDatas = new bytes[](length);
 
-    for (uint256 i; i < tos.length; ++i) {
+    for (uint256 i; i < length; ++i) {
       (results[i], returnDatas[i]) = tos[i].call{ value: values[i] }(callDatas[i]);
       results[i].handleRevert(returnDatas[i]);
     }


### PR DESCRIPTION
### Description
This PR mainly removes `multiMint` and `kill` func in `OwnedMulticaller` contract for more general usecases, not just only for RNS contracts.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
